### PR TITLE
Correct some edge cases in GetRandomDate()

### DIFF
--- a/source/Utils/PeanutButter.Utils/DateTimeExtensions.cs
+++ b/source/Utils/PeanutButter.Utils/DateTimeExtensions.cs
@@ -81,9 +81,9 @@ namespace PeanutButter.Utils
                                             int hours = 0, 
                                             int minutes = 0, 
                                             int seconds = 0, 
-                                            int microseconds = 0)
+                                            int milliseconds = 0)
         {
-            return new DateTime(years, months, days, hours, minutes, seconds, microseconds, kind);
+            return new DateTime(years, months, days, hours, minutes, seconds, milliseconds, kind);
         }
 
         public static int Microseconds(this DateTime value)


### PR DESCRIPTION
* Always use 30 year range for dates unless BOTH minDate and maxDate are given
* Ignore minTime and maxTime if dateOnly is true
* Consider milliseconds when enforcing minTime and maxTime
* Balance distribution of random values when dateOnly is true