### PR TITLE
bug: fixed DeepClone for objects with writable indexer properties

### DIFF
--- a/source/Utils/PeanutButter.Utils.Tests/TestObjectExtensions.cs
+++ b/source/Utils/PeanutButter.Utils.Tests/TestObjectExtensions.cs
@@ -1708,6 +1708,32 @@ namespace PeanutButter.Utils.Tests
                 Expect(result.Prop).Not.To.Be.Null();
                 Expect(result.Prop).To.Be.Deep.Equivalent.To(src.Prop);
             }
+
+            public class HasWritableIndexer
+            {
+                public string NormalProp { get; set; }
+                public object this[int index]
+                {
+                    get { return null; }
+                    set { }
+                }
+            }
+
+            [Test]
+            public void ShouldCloneAObjectWithAWritableIndexer()
+            {
+                // Arrange
+                var src = new HasWritableIndexer()
+                {
+                    NormalProp = "value"
+                };
+                // Pre-Assert
+                // Act
+                var result = src.DeepClone();
+                // Assert
+                Expect(result).Not.To.Be.Null();
+                Expect(result.NormalProp).To.Equal(src.NormalProp);
+            }
         }
 
         [TestFixture]

--- a/source/Utils/PeanutButter.Utils/ObjectExtensions.cs
+++ b/source/Utils/PeanutButter.Utils/ObjectExtensions.cs
@@ -331,7 +331,8 @@ namespace PeanutButter.Utils
                 .Where(pi => !ignoreProperties.Contains(pi.Name));
             var dstPropInfos = dst.GetType().GetProperties();
 
-            foreach (var srcPropInfo in srcPropInfos.Where(pi => pi.CanRead))
+            foreach (var srcPropInfo in srcPropInfos.Where(pi => pi.CanRead &&
+                                                                 pi.GetIndexParameters().Length == 0))
             {
                 var matchingTarget = dstPropInfos.FirstOrDefault(dp => dp.Name == srcPropInfo.Name &&
                                                                        dp.PropertyType == srcPropInfo.PropertyType &&
@@ -540,11 +541,11 @@ namespace PeanutButter.Utils
 
         private static readonly Func<object, Type, object>[] _cloneStrategies =
         {
-            CloneObject,
             CloneArray,
             CloneList,
             CloneDictionary,
-            CloneEnumerable
+            CloneEnumerable,
+            CloneObject
         };
 
         private static object CloneDictionary(object src, Type cloneType)


### PR DESCRIPTION
Hey dude

I came across a tiny bug in PB when I upgraded to the latest version.

Cheers
Cobus
