### PR TITLE
Adds ability to set or override MySQL configuration settings

### DIFF
--- a/source/TempDb/PeanutButter.TempDb.MySql.Base/TempDbMySqlServerSettings.cs
+++ b/source/TempDb/PeanutButter.TempDb.MySql.Base/TempDbMySqlServerSettings.cs
@@ -1,6 +1,7 @@
 ﻿// ReSharper disable UnusedMember.Global
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace PeanutButter.TempDb.MySql.Base
@@ -58,6 +59,13 @@ namespace PeanutButter.TempDb.MySql.Base
             /// </summary>
             public bool ForceFindMySqlInPath { get; set; }
         }
+        
+        /// <summary>
+        /// Allows any other configuration/settings to be specified - any duplicates of first class
+        /// configuration settings will override the first class setting
+        /// </summary>
+        public Dictionary<string, string> CustomConfiguration {get; set;} = new Dictionary<string, string>();
+        
 
         /// <summary>
         /// Options for the instantiation of the temporary database


### PR DESCRIPTION
Previously, only a subset of MySQL configuration keys could be specified. With this change, any MySQL configuration file setting can be specified. 

Note, if a duplicate of a first class setting is configured in the custom configuration, the custom configuration wins. This is to support folks storing their configuration in another format (example an ini file or JSON) and then applying this generically (i.e. they want to override the defaults).