### PR TITLE
Added ability to optimise mysql tempdb for performance

### DIFF
--- a/source/TempDb/PeanutButter.TempDb.MySql.Base/TempDbMySqlServerSettings.cs
+++ b/source/TempDb/PeanutButter.TempDb.MySql.Base/TempDbMySqlServerSettings.cs
@@ -176,7 +176,7 @@ namespace PeanutButter.TempDb.MySql.Base
         /// mysql server setting
         /// </summary>
         [Setting("innodb_thread_concurrency")]
-        public int InnodbThreadConcurrency { get; set; } = 8;
+        public int InnodbThreadConcurrency { get; set; } = 0;
 
         /// <summary>
         /// mysql server setting
@@ -195,6 +195,24 @@ namespace PeanutButter.TempDb.MySql.Base
         /// </summary>
         [Setting("innodb_flush_log_at_trx_commit")]
         public int InnodbFlushLogAtTrxCommit { get; set; } = 1;
+
+        /// <summary>
+        /// mysql server setting
+        /// </summary> 
+        [Setting("innodb_flush_log_at_timeout")]
+        public int InnodbFlushLogAtTimeout { get; set; } = 1;
+
+        /// <summary>
+        /// mysql server setting
+        /// </summary> 
+        [Setting("sync_binlog")]
+        public int SyncBinLog { get; set; } = 1;
+        
+        /// <summary>
+        /// mysql server setting
+        /// </summary>
+        [Setting("innodb_io_capacity")]
+        public int InnoDbIoCapacity { get; set; } = 200;
 
         /// <summary>
         /// mysql server setting
@@ -248,7 +266,7 @@ namespace PeanutButter.TempDb.MySql.Base
         /// mysql server setting
         /// </summary>
         [Setting("slow-query-log")]
-        public int SlowQueryLog { get; set; } = 1;
+        public int SlowQueryLog { get; set; } = 0;
 
         /// <summary>
         /// mysql server setting
@@ -291,5 +309,24 @@ namespace PeanutButter.TempDb.MySql.Base
         /// </summary>
         [Setting("socket")]
         public string Socket { get; set; } = $"/tmp/mysql-temp-{Guid.NewGuid()}.socket";
+
+        /// <summary>
+        /// Optimises configuration for performance. Warning, this has an effect on durability in the event
+        /// of a server crash. If you care about your data in the event of a system/process crash, do not
+        /// use this.
+        /// </summary>
+        /// <param name="isRunningOnSsdDisk"></param>
+        public void OptimizeForPerformance(bool isRunningOnSsdDisk = false)
+        {
+            SlowQueryLog = 0;
+            GeneralLog = 0;
+            InnodbThreadConcurrency = 0;
+            InnodbFlushLogAtTrxCommit = 2;
+            InnodbFlushLogAtTimeout = 10;
+            SyncBinLog = 0;
+            InnoDbIoCapacity = isRunningOnSsdDisk
+                ? 3000
+                : InnoDbIoCapacity;
+        }
     }
 }

--- a/source/TempDb/PeanutButter.TempDb.MySql.Base/TempDbMySqlServerSettings.cs
+++ b/source/TempDb/PeanutButter.TempDb.MySql.Base/TempDbMySqlServerSettings.cs
@@ -314,9 +314,21 @@ namespace PeanutButter.TempDb.MySql.Base
         /// Optimises configuration for performance. Warning, this has an effect on durability in the event
         /// of a server crash. If you care about your data in the event of a system/process crash, do not
         /// use this.
+        /// This overload optimises to run on a non-SSD disk
         /// </summary>
-        /// <param name="isRunningOnSsdDisk"></param>
-        public TempDbMySqlServerSettings OptimizeForPerformance(bool isRunningOnSsdDisk = false)
+        public TempDbMySqlServerSettings OptimizeForPerformance()
+        {
+            OptimizeForPerformance(false);
+        }
+        
+        /// <summary>
+        /// Optimises configuration for performance. Warning, this has an effect on durability in the event
+        /// of a server crash. If you care about your data in the event of a system/process crash, do not
+        /// use this.
+        /// </summary>
+        /// <param name="isRunningOnSsdDisk">Set this to true to cap off InnoDbIoCapacity to 3000 (for 
+        /// spinning rust disks)</param>
+        public TempDbMySqlServerSettings OptimizeForPerformance(bool isRunningOnSsdDisk)
         {
             SlowQueryLog = 0;
             GeneralLog = 0;

--- a/source/TempDb/PeanutButter.TempDb.MySql.Base/TempDbMySqlServerSettings.cs
+++ b/source/TempDb/PeanutButter.TempDb.MySql.Base/TempDbMySqlServerSettings.cs
@@ -316,7 +316,7 @@ namespace PeanutButter.TempDb.MySql.Base
         /// use this.
         /// </summary>
         /// <param name="isRunningOnSsdDisk"></param>
-        public void OptimizeForPerformance(bool isRunningOnSsdDisk = false)
+        public TempDbMySqlServerSettings OptimizeForPerformance(bool isRunningOnSsdDisk = false)
         {
             SlowQueryLog = 0;
             GeneralLog = 0;
@@ -327,6 +327,7 @@ namespace PeanutButter.TempDb.MySql.Base
             InnoDbIoCapacity = isRunningOnSsdDisk
                 ? 3000
                 : InnoDbIoCapacity;
+            return this;
         }
     }
 }

--- a/source/TempDb/PeanutButter.TempDb.Tests/PeanutButter.TempDb.Tests.csproj
+++ b/source/TempDb/PeanutButter.TempDb.Tests/PeanutButter.TempDb.Tests.csproj
@@ -66,6 +66,7 @@
     <Compile Include="TestTempDBLocalDb.cs" />
     <Compile Include="TestTempDBMySqlConnector.cs" />
     <Compile Include="TestTempDbMySqlData.cs" />
+    <Compile Include="TestTempDbMySqlServerSettings.cs" />
     <Compile Include="TestTempDBSqlCe.cs" />
     <Compile Include="TestTempDBSqlite.cs" />
   </ItemGroup>

--- a/source/TempDb/PeanutButter.TempDb.Tests/TestMySqlConfigGenerator.cs
+++ b/source/TempDb/PeanutButter.TempDb.Tests/TestMySqlConfigGenerator.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using NExpect;
 using NUnit.Framework;
-using PeanutButter.TempDb.MySql;
 using PeanutButter.TempDb.MySql.Base;
 using PeanutButter.Utils;
 using static NExpect.Expectations;
@@ -106,7 +105,7 @@ sql-mode=""STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION""
 log-output=FILE
 general-log=0
 general_log_file=""mysql-general.log""
-slow-query-log=1
+slow-query-log=0
 slow_query_log_file=""mysql-slow.log""
 long_query_time=10
 log-error=""mysql-err.log""
@@ -118,13 +117,15 @@ myisam_max_sort_file_size=100G
 innodb_flush_log_at_trx_commit=1
 innodb_buffer_pool_size=384M
 innodb_log_file_size=48M
-innodb_thread_concurrency=8
+innodb_thread_concurrency=0
 innodb_autoextend_increment=64
 innodb_concurrency_tickets=5000
 innodb_old_blocks_time=1000
 innodb_stats_on_metadata=0
 innodb_file_per_table=1
 innodb_checksum_algorithm=0
+innodb_flush_log_at_timeout = 1
+innodb_io_capacity = 200
 back_log=80
 flush_time=0
 join_buffer_size=256K
@@ -137,6 +138,7 @@ binlog_row_event_max_size=8K
 sync_master_info=10000
 sync_relay_log=10000
 sync_relay_log_info=10000
+sync_binlog = 1
 ";
     }
 }

--- a/source/TempDb/PeanutButter.TempDb.Tests/TestTempDbMySqlServerSettings.cs
+++ b/source/TempDb/PeanutButter.TempDb.Tests/TestTempDbMySqlServerSettings.cs
@@ -39,5 +39,18 @@ namespace PeanutButter.TempDb.Tests
             // assert
             Expect(sut.InnoDbIoCapacity).To.Equal(3000);
         }
+
+        [Test]
+        public void WhenOptimizedForPerformance_ShouldReturnSelf()
+        {
+            // arrange
+            var sut = new TempDbMySqlServerSettings();
+            
+            // act
+            var result = sut.OptimizeForPerformance();
+            
+            // assert
+            Expect(result).To.Be.An.Instance.Of<TempDbMySqlServerSettings>();
+        }
     }
 }

--- a/source/TempDb/PeanutButter.TempDb.Tests/TestTempDbMySqlServerSettings.cs
+++ b/source/TempDb/PeanutButter.TempDb.Tests/TestTempDbMySqlServerSettings.cs
@@ -1,0 +1,43 @@
+using NExpect;
+using NUnit.Framework;
+using PeanutButter.TempDb.MySql.Base;
+using static NExpect.Expectations;
+
+namespace PeanutButter.TempDb.Tests
+{
+    [TestFixture]
+    public class TestTempDbMySqlServerSettings
+    {
+        [Test]
+        public void WhenOptimizedForPerformance_ShouldUpdateConfigAppropriately()
+        {
+            // arrange
+            var sut = new TempDbMySqlServerSettings();
+
+            // act
+            sut.OptimizeForPerformance();
+
+            // assert
+            Expect(sut.GeneralLog).To.Equal(0);
+            Expect(sut.SlowQueryLog).To.Equal(0);
+            Expect(sut.SyncBinLog).To.Equal(0);
+            Expect(sut.InnoDbIoCapacity).To.Equal(200);
+            Expect(sut.InnodbThreadConcurrency).To.Equal(0);
+            Expect(sut.InnodbFlushLogAtTimeout).To.Equal(10);
+            Expect(sut.InnodbFlushLogAtTrxCommit).To.Equal(2);
+        }
+        
+        [Test]
+        public void WhenOptimizedForPerformanceOnSSD_ShouldIncreaseIOCapacity()
+        {
+            // arrange
+            var sut = new TempDbMySqlServerSettings();
+
+            // act
+            sut.OptimizeForPerformance(isRunningOnSsdDisk: true);
+
+            // assert
+            Expect(sut.InnoDbIoCapacity).To.Equal(3000);
+        }
+    }
+}


### PR DESCRIPTION
Using the following:

```csharp
var settings = new TempDbMySqlServerSettings();
settings.OptimizeForPerformance();
```

One is able to optimise MySQL for performance when running with TempDb. There is an optional flag to indicate whether you are running on an SSD and want to ramp up the disk IO configuration.