### PR TITLE
Fix parse failure due to semi-colons in data portion of INI entry

### DIFF
--- a/source/INI/PeanutButter.INI/INIFile.cs
+++ b/source/INI/PeanutButter.INI/INIFile.cs
@@ -386,7 +386,7 @@ namespace PeanutButter.INIFile
         private bool HaveUnmatchedQuotesIn(IEnumerable<string> parts)
         {
             var joined = string.Join(";", parts);
-                if (!joined.EndsWith('"'))
+                if (!joined.Trim().EndsWith('"'))
                     return true;
             var quoted = joined.Count(c => c == '"');
             return quoted % 2 != 0;


### PR DESCRIPTION
If data-portion of Line doesn't end with double-quote, continue data-portion parsing even if detecting even number of double-quotes.