### PR TITLE
Allow quotes to be toggled when persisting INI file

### DIFF
--- a/source/INI/PeanutButter.INI.Tests/TestINIFile.cs
+++ b/source/INI/PeanutButter.INI.Tests/TestINIFile.cs
@@ -1633,6 +1633,123 @@ key=value
                 .Parse(Arg.Any<string>());
         }
 
+        public class WrapValueInQuotes
+        {
+            [Test]
+            public void WrapValueInQuotes_GivenWrapValueInQuotesTrue_WhenValueHasValue_ShouldWriteValueWithQuotesToStream()
+            {
+                //---------------Set up test pack-------------------
+                var sut = Create();
+                sut.WrapValueInQuotes = true;
+                sut[""]["foo"] = "bar";
+
+                //---------------Assert Precondition----------------
+
+                //---------------Execute Test ----------------------
+                using var memStream = new MemoryStream(new byte[1024], true);
+                sut.Persist(memStream);
+
+                //---------------Test Result -----------------------
+                var result = Encoding.UTF8.GetString(memStream.ReadAllBytes()).Split('\0').First();
+                Expect(result).To.Equal("foo=\"bar\"");
+            }
+
+            [Test]
+            public void WrapValueInQuotes_GivenWrapValueInQuotesTrue_WhenValueIsNull_ShouldWriteOnlyKeyToStream()
+            {
+                //---------------Set up test pack-------------------
+                var sut = Create();
+                sut.WrapValueInQuotes = true;
+                sut[""]["foo"] = null;
+
+                //---------------Assert Precondition----------------
+
+                //---------------Execute Test ----------------------
+                using var memStream = new MemoryStream(new byte[1024], true);
+                sut.Persist(memStream);
+
+                //---------------Test Result -----------------------
+                var result = Encoding.UTF8.GetString(memStream.ReadAllBytes()).Split('\0').First();
+                Expect(result).To.Equal("foo");
+            }
+
+            [Test]
+            public void WrapValueInQuotes_GivenWrapValueInQuotesTrue_WhenValueIsEmptyString_ShouldWriteKeyWithEqualsAndQuotesToStream()
+            {
+                //---------------Set up test pack-------------------
+                var sut = Create();
+                sut.WrapValueInQuotes = true;
+                sut[""]["foo"] = string.Empty;
+
+                //---------------Assert Precondition----------------
+
+                //---------------Execute Test ----------------------
+                using var memStream = new MemoryStream(new byte[1024], true);
+                sut.Persist(memStream);
+
+                //---------------Test Result -----------------------
+                var result = Encoding.UTF8.GetString(memStream.ReadAllBytes()).Split('\0').First();
+                Expect(result).To.Equal("foo=\"\"");
+            }
+
+            [Test]
+            public void WrapValueInQuotes_GivenWrapValueInQuotesFalse_WhenValueHasValue_ShouldWriteValueWithoutQuotesToStream()
+            {
+                //---------------Set up test pack-------------------
+                var sut = Create();
+                sut.WrapValueInQuotes = false;
+                sut[""]["foo"] = "bar";
+
+                //---------------Assert Precondition----------------
+
+                //---------------Execute Test ----------------------
+                using var memStream = new MemoryStream(new byte[1024], true);
+                sut.Persist(memStream);
+
+                //---------------Test Result -----------------------
+                var result = Encoding.UTF8.GetString(memStream.ReadAllBytes()).Split('\0').First();
+                Expect(result).To.Equal("foo=bar");
+            }
+
+            [Test]
+            public void WrapValueInQuotes_GivenWrapValueInQuotesFalse_WhenValueIsNull_ShouldWriteOnlyKeyToStream()
+            {
+                //---------------Set up test pack-------------------
+                var sut = Create();
+                sut.WrapValueInQuotes = false;
+                sut[""]["foo"] = null;
+
+                //---------------Assert Precondition----------------
+
+                //---------------Execute Test ----------------------
+                using var memStream = new MemoryStream(new byte[1024], true);
+                sut.Persist(memStream);
+
+                //---------------Test Result -----------------------
+                var result = Encoding.UTF8.GetString(memStream.ReadAllBytes()).Split('\0').First();
+                Expect(result).To.Equal("foo");
+            }
+
+            [Test]
+            public void WrapValueInQuotes_GivenWrapValueInQuotesFalse_WhenValueIsEmptyString_ShouldWriteKeyWithEqualsToStream()
+            {
+                //---------------Set up test pack-------------------
+                var sut = Create();
+                sut.WrapValueInQuotes = false;
+                sut[""]["foo"] = string.Empty;
+
+                //---------------Assert Precondition----------------
+
+                //---------------Execute Test ----------------------
+                using var memStream = new MemoryStream(new byte[1024], true);
+                sut.Persist(memStream);
+
+                //---------------Test Result -----------------------
+                var result = Encoding.UTF8.GetString(memStream.ReadAllBytes()).Split('\0').First();
+                Expect(result).To.Equal("foo=");
+            }
+        }
+
         private static string RandString()
         {
             return GetRandomAlphaString(1, 10);

--- a/source/INI/PeanutButter.INI/INIFile.cs
+++ b/source/INI/PeanutButter.INI/INIFile.cs
@@ -22,6 +22,11 @@ namespace PeanutButter.INI
         string SectionSeparator { get; set; }
 
         /// <summary>
+        /// Toggle whether key values are wrapped in quote marks when persisted
+        /// </summary>
+        bool WrapValueInQuotes { get; set; }
+
+        /// <summary>
         /// Exposes the path of the loaded INIFile
         /// </summary>
         string Path { get; }
@@ -270,6 +275,9 @@ namespace PeanutButter.INI
 
         /// <inheritdoc />
         public string SectionSeparator { get; set; } = "";
+
+        /// <inheritdoc />
+        public bool WrapValueInQuotes { get; set; } = true;
 
         /// <inheritdoc />
         public IEnumerable<string> Sections => Data.Keys;
@@ -899,9 +907,11 @@ namespace PeanutButter.INI
             var lines = new List<string>();
             AddCommentsTo(lines, section, key);
             var dataValue = this[section][key];
-            var writeValue = dataValue == null
-                ? ""
-                : $"=\"{EscapeEntities(dataValue, section, key)}\"";
+            var writeValue = string.Empty;
+            if (dataValue is not null)
+            {
+                writeValue = WrapValueInQuotes ? $"=\"{EscapeEntities(dataValue, section, key)}\"" : $"={EscapeEntities(dataValue, section, key)}";
+            }
             lines.Add(string.Join(string.Empty, key.Trim(), writeValue));
             return string.Join(Environment.NewLine, lines);
         }


### PR DESCRIPTION
Currently the library allows the user to read in values which don't have quotes but then when a modification is made and is persisted it will add quotes to all values.

Added functionality to disable to wrapping of values with quotes on persist.