### PR TITLE
SimpleHttpServer: Added support for further HTTP methods

### DIFF
--- a/source/SimpleServers/PeanutButter.SimpleHTTPServer.Tests/TestHttpServer.cs
+++ b/source/SimpleServers/PeanutButter.SimpleHTTPServer.Tests/TestHttpServer.cs
@@ -175,8 +175,12 @@ namespace PeanutButter.SimpleHTTPServer.Tests
             public string Name { get; set; }
         }
 
-        [Test]
-        public async Task GettingPostBody()
+        [TestCase("POST")]
+        [TestCase("PUT")]
+        [TestCase("UPDATE")]
+        [TestCase("DELETE")]
+        [TestCase("PATCH")]
+        public async Task GettingRequestBody(string method)
         {
             // Arrange
             using var server = new HttpServer();
@@ -185,13 +189,14 @@ namespace PeanutButter.SimpleHTTPServer.Tests
                 id = 1,
                 name = "moo"
             };
+            var path = $"/{method.ToLower()}";
             var expectedBody = JsonConvert.SerializeObject(poco);
             string body = null;
             PostBody bodyObject = null;
             server.AddJsonDocumentHandler(
                 (processor, stream) =>
                 {
-                    if (processor.Path != "/post")
+                    if (processor.Path != path)
                         return null;
                     body = stream.AsString();
                     bodyObject = stream.As<PostBody>();
@@ -205,10 +210,9 @@ namespace PeanutButter.SimpleHTTPServer.Tests
             // Act
             var client = new HttpClient();
             var message = new HttpRequestMessage(
-                HttpMethod.Post,
-                server.GetFullUrlFor("/post"))
+                new HttpMethod(method),
+                server.GetFullUrlFor(path))
             {
-                Method = HttpMethod.Post,
                 Content = new ObjectContent<object>(
                     poco,
                     new JsonMediaTypeFormatter())

--- a/source/SimpleServers/PeanutButter.SimpleHTTPServer.Tests/TestHttpServer.cs
+++ b/source/SimpleServers/PeanutButter.SimpleHTTPServer.Tests/TestHttpServer.cs
@@ -177,7 +177,6 @@ namespace PeanutButter.SimpleHTTPServer.Tests
 
         [TestCase("POST")]
         [TestCase("PUT")]
-        [TestCase("UPDATE")]
         [TestCase("DELETE")]
         [TestCase("PATCH")]
         public async Task GettingRequestBody(string method)

--- a/source/SimpleServers/PeanutButter.SimpleHTTPServer/HttpConstants.cs
+++ b/source/SimpleServers/PeanutButter.SimpleHTTPServer/HttpConstants.cs
@@ -33,6 +33,26 @@ namespace PeanutButter.SimpleHTTPServer
             /// POST
             /// </summary>
             public const string POST = "POST";
+
+            /// <summary>
+            /// PUT method.
+            /// </summary>
+            public const string PUT = "PUT";
+
+            /// <summary>
+            /// UPDATE method.
+            /// </summary>
+            public const string UPDATE = "UPDATE";
+
+            /// <summary>
+            /// DELETE method.
+            /// </summary>
+            public const string DELETE = "DELETE";
+
+            /// <summary>
+            /// PATCH method.
+            /// </summary>
+            public const string PATCH = "PATCH";
         }
 
         /// <summary>

--- a/source/SimpleServers/PeanutButter.SimpleHTTPServer/HttpConstants.cs
+++ b/source/SimpleServers/PeanutButter.SimpleHTTPServer/HttpConstants.cs
@@ -40,11 +40,6 @@ namespace PeanutButter.SimpleHTTPServer
             public const string PUT = "PUT";
 
             /// <summary>
-            /// UPDATE method.
-            /// </summary>
-            public const string UPDATE = "UPDATE";
-
-            /// <summary>
             /// DELETE method.
             /// </summary>
             public const string DELETE = "DELETE";

--- a/source/SimpleServers/PeanutButter.SimpleHTTPServer/HttpProcessor.cs
+++ b/source/SimpleServers/PeanutButter.SimpleHTTPServer/HttpProcessor.cs
@@ -121,26 +121,20 @@ namespace PeanutButter.SimpleHTTPServer
         /// Handles the request, given an IO wrapper
         /// </summary>
         /// <param name="io"></param>
-        public void HandleRequest(TcpIoWrapper io)
+        protected void HandleRequest(TcpIoWrapper io)
         {
             if (Method.Equals(Methods.GET))
             {
-                HandleGETRequest();
-                return;
-            }
-
-            if (Method.Equals(Methods.POST))
-            {
-                HandlePOSTRequest(io.RawStream);
+                this.HandleRequestWithoutBody(Method);
                 return;
             }
 
             if (Method.Equals(Methods.PUT)
                 || Method.Equals(Methods.DELETE)
-                || Method.Equals(Methods.PATCH))
+                || Method.Equals(Methods.PATCH)
+                || Method.Equals(Methods.POST))
             {
                 this.HandleRequestWithBody(io.RawStream, Method);
-                return;
             }
         }
 
@@ -215,20 +209,11 @@ namespace PeanutButter.SimpleHTTPServer
         }
 
         /// <summary>
-        /// Handles this request as a GET
+        /// Handles a request that does not contain a body (as of the HTTP spec).
         /// </summary>
-        public void HandleGETRequest()
+        private void HandleRequestWithoutBody(string method)
         {
-            Server.HandleGETRequest(this);
-        }
-
-        /// <summary>
-        /// Handles this request as a POST
-        /// </summary>
-        /// <param name="stream"></param>
-        public void HandlePOSTRequest(Stream stream)
-        {
-            this.HandleRequestWithBody(stream, Methods.POST);
+            Server.HandleRequestWithoutBody(this, method);
         }
 
         private void HandleRequestWithBody(Stream stream, string method)

--- a/source/SimpleServers/PeanutButter.SimpleHTTPServer/HttpProcessor.cs
+++ b/source/SimpleServers/PeanutButter.SimpleHTTPServer/HttpProcessor.cs
@@ -136,7 +136,6 @@ namespace PeanutButter.SimpleHTTPServer
             }
 
             if (Method.Equals(Methods.PUT)
-                || Method.Equals(Methods.UPDATE)
                 || Method.Equals(Methods.DELETE)
                 || Method.Equals(Methods.PATCH))
             {

--- a/source/SimpleServers/PeanutButter.SimpleHTTPServer/HttpProcessor.cs
+++ b/source/SimpleServers/PeanutButter.SimpleHTTPServer/HttpProcessor.cs
@@ -236,13 +236,13 @@ namespace PeanutButter.SimpleHTTPServer
         {
             using (var ms = new MemoryStream())
             {
-                if (this.HttpHeaders.ContainsKey(Headers.CONTENT_LENGTH))
+                if (HttpHeaders.ContainsKey(Headers.CONTENT_LENGTH))
                 {
-                    var contentLength = Convert.ToInt32(this.HttpHeaders[Headers.CONTENT_LENGTH]);
-                    if (contentLength > this.MaxPostSize)
+                    var contentLength = Convert.ToInt32(HttpHeaders[Headers.CONTENT_LENGTH]);
+                    if (contentLength > MaxPostSize)
                     {
                         throw new Exception(
-                            $"{method} Content-Length({contentLength}) too big for this simple server (max: {this.MaxPostSize})");
+                            $"{method} Content-Length({contentLength}) too big for this simple server (max: {MaxPostSize})");
                     }
 
                     var buf = new byte[BUF_SIZE];
@@ -269,8 +269,8 @@ namespace PeanutButter.SimpleHTTPServer
                     ms.Seek(0, SeekOrigin.Begin);
                 }
 
-                this.ParseFormElementsIfRequired(ms);
-                this.Server.HandleRequestWithBody(this, ms, method);
+                ParseFormElementsIfRequired(ms);
+                Server.HandleRequestWithBody(this, ms, method);
             }
         }
 

--- a/source/SimpleServers/PeanutButter.SimpleHTTPServer/HttpProcessor.cs
+++ b/source/SimpleServers/PeanutButter.SimpleHTTPServer/HttpProcessor.cs
@@ -229,7 +229,7 @@ namespace PeanutButter.SimpleHTTPServer
         /// <param name="stream"></param>
         public void HandlePOSTRequest(Stream stream)
         {
-            this.HandleRequestWithBody(stream, "POST");
+            this.HandleRequestWithBody(stream, Methods.POST);
         }
 
         private void HandleRequestWithBody(Stream stream, string method)

--- a/source/SimpleServers/PeanutButter.SimpleHTTPServer/HttpServer.cs
+++ b/source/SimpleServers/PeanutButter.SimpleHTTPServer/HttpServer.cs
@@ -351,13 +351,6 @@ namespace PeanutButter.SimpleHTTPServer
             });
         }
 
-        /// <inheritdoc />
-        public override void HandleGETRequest(HttpProcessor p)
-        {
-            Log("Incoming GET request: {0}", p.FullUrl);
-            InvokeHandlersWith(p, null);
-        }
-
         private void InvokeHandlersWith(HttpProcessor p, Stream stream)
         {
             var handled = false;
@@ -398,10 +391,10 @@ namespace PeanutButter.SimpleHTTPServer
         }
 
         /// <inheritdoc />
-        public override void HandlePOSTRequest(HttpProcessor p, Stream inputData)
+        public override void HandleRequestWithoutBody(HttpProcessor p, string method)
         {
-            Log("Incoming POST request: {0}", p.FullUrl);
-            InvokeHandlersWith(p, inputData);
+            Log($"Incoming {method} request: {p.FullUrl}");
+            InvokeHandlersWith(p, null);
         }
 
         public override void HandleRequestWithBody(HttpProcessor p, MemoryStream inputData, string method)

--- a/source/SimpleServers/PeanutButter.SimpleHTTPServer/HttpServer.cs
+++ b/source/SimpleServers/PeanutButter.SimpleHTTPServer/HttpServer.cs
@@ -404,6 +404,12 @@ namespace PeanutButter.SimpleHTTPServer
             InvokeHandlersWith(p, inputData);
         }
 
+        public override void HandleRequestWithBody(HttpProcessor p, MemoryStream inputData, string method)
+        {
+            Log($"Incoming {method} request: {p.FullUrl}");
+            InvokeHandlersWith(p, inputData);
+        }
+
         /// <summary>
         /// Serves an XDocument from the provided path, for the provided method
         /// </summary>

--- a/source/SimpleServers/PeanutButter.SimpleHTTPServer/HttpServerBase.cs
+++ b/source/SimpleServers/PeanutButter.SimpleHTTPServer/HttpServerBase.cs
@@ -45,17 +45,11 @@ namespace PeanutButter.SimpleHTTPServer
         }
 
         /// <summary>
-        /// Handles a GET request
+        /// Handles a request that does not contain a body (as of the HTTP spec).
         /// </summary>
-        /// <param name="p"></param>
-        public abstract void HandleGETRequest(HttpProcessor p);
-
-        /// <summary>
-        /// Handles a POST request
-        /// </summary>
-        /// <param name="p"></param>
-        /// <param name="inputData"></param>
-        public abstract void HandlePOSTRequest(HttpProcessor p, Stream inputData);
+        /// <param name="p">The HTTP processor.</param>
+        /// <param name="method">The HTTP method.</param>
+        public abstract void HandleRequestWithoutBody(HttpProcessor p, string method);
 
         /// <summary>
         /// Handles a general request with a request body.

--- a/source/SimpleServers/PeanutButter.SimpleHTTPServer/HttpServerBase.cs
+++ b/source/SimpleServers/PeanutButter.SimpleHTTPServer/HttpServerBase.cs
@@ -56,5 +56,13 @@ namespace PeanutButter.SimpleHTTPServer
         /// <param name="p"></param>
         /// <param name="inputData"></param>
         public abstract void HandlePOSTRequest(HttpProcessor p, Stream inputData);
+
+        /// <summary>
+        /// Handles a general request with a request body.
+        /// </summary>
+        /// <param name="p">The HTTP processor.</param>
+        /// <param name="inputData">The stream to read the request body from.</param>
+        /// <param name="method">The HTTP method.</param>
+        public abstract void HandleRequestWithBody(HttpProcessor p, MemoryStream inputData, string method);
     }
 }


### PR DESCRIPTION
For I needed the `SimpleHttpServer` to support the `PUT` and `PATCH` methods for my tests, I supplied them on my own. 