### PR TITLE
Fix for stopping working on high load

### DIFF
--- a/source/SimpleServers/PeanutButter.SimpleHTTPServer/HttpProcessor.cs
+++ b/source/SimpleServers/PeanutButter.SimpleHTTPServer/HttpProcessor.cs
@@ -389,7 +389,8 @@ namespace PeanutButter.SimpleHTTPServer
                 _outputStream.Flush();
                 _outputStream.BaseStream.Write(data, 0, data.Length);
                 _outputStream.BaseStream.Flush();
-            }catch(Exception ex)
+            }
+            catch(Exception ex)
             {
                 LogAction(ex.Message);
             }

--- a/source/SimpleServers/PeanutButter.SimpleHTTPServer/HttpProcessor.cs
+++ b/source/SimpleServers/PeanutButter.SimpleHTTPServer/HttpProcessor.cs
@@ -384,9 +384,15 @@ namespace PeanutButter.SimpleHTTPServer
         public void WriteDataToStream(byte[] data)
         {
             if (data == null) return;
-            _outputStream.Flush();
-            _outputStream.BaseStream.Write(data, 0, data.Length);
-            _outputStream.BaseStream.Flush();
+            try
+            {
+                _outputStream.Flush();
+                _outputStream.BaseStream.Write(data, 0, data.Length);
+                _outputStream.BaseStream.Flush();
+            }catch(Exception ex)
+            {
+                LogAction(ex.Message);
+            }
         }
 
         /// <summary>

--- a/source/SimpleServers/PeanutButter.SimpleHTTPServer/TcpClientExtensions.cs
+++ b/source/SimpleServers/PeanutButter.SimpleHTTPServer/TcpClientExtensions.cs
@@ -18,8 +18,9 @@ namespace PeanutButter.SimpleHTTPServer
         public static string ReadLine(this TcpClient client)
         {
             var stream = client.GetStream();
+            stream.ReadTimeout = 3000;
             var data = new List<char>();
-            while (true)
+            while (true && stream.DataAvailable)
             {
                 var thisChar = stream.ReadByte();
                 if (thisChar == '\n') break;

--- a/source/SimpleServers/PeanutButter.SimpleHTTPServer/TcpIoWrapper.cs
+++ b/source/SimpleServers/PeanutButter.SimpleHTTPServer/TcpIoWrapper.cs
@@ -49,8 +49,15 @@ namespace PeanutButter.SimpleHTTPServer
 
         private void DisposeStreamWriter()
         {
-            _outputStreamWriter?.Flush();
-            _outputStreamWriter?.Dispose();
+            try
+            {
+                _outputStreamWriter?.Flush();
+                _outputStreamWriter?.Dispose();
+            }
+            catch
+            {
+                /* intentionally left blank */
+            }
             _outputStreamWriter = null;
         }
 


### PR DESCRIPTION
On highload test disposing of network stream causes app crash without possibility to catch it.