### PR TITLE
Allow specifying values which should not be generated within GetRandomInt and GetRandomLong

### DIFF
--- a/source/TestUtils/PeanutButter.RandomGenerators.Tests/TestRandomValueGen.cs
+++ b/source/TestUtils/PeanutButter.RandomGenerators.Tests/TestRandomValueGen.cs
@@ -98,6 +98,76 @@ namespace PeanutButter.RandomGenerators.Tests
                 // Assert
                 Assert.Fail($"Unable to find {max} in range {min} - {max} over {HIGH_RANDOM_TEST_CYCLES} attempts");
             }
+
+            [TestFixture]
+            public class WithExcludeParameter
+            {
+                [TestFixture]
+                public class WhenExcludeParameterIsEqualToMinValueOrMaxValue
+                {
+                    [Test]
+                    public void ShouldThrow()
+                    {
+                        // Arrange
+                        // Act
+                        // Assert
+                        Expect(() => GetRandomInt(1, 100, 100))
+                            .To.Throw<ArgumentException>()
+                            .With.Message.Containing("The exclude parameter can not be equal to minValue or maxValue");
+                        
+                        Expect(() => GetRandomInt(1, 100, 1))
+                            .To.Throw<ArgumentException>()
+                            .With.Message.Containing("The exclude parameter can not be equal to minValue or maxValue");
+                    }
+                }
+
+                [TestFixture]
+                public class WithSingleExcludeFuncParameter
+                {
+                    [Test]
+                    [Repeat(10)]
+                    public void ShouldExcludeParameter()
+                    {
+                        // arrange
+                        var randomNumber = GetRandomInt(100, 102, () => 101);
+                        // act
+                        // assert
+                        Expect(randomNumber).To.Not.Equal(101);
+                    }
+                }
+
+                [TestFixture]
+                public class WithArrayOfExcludeFuncParameters
+                {
+                    [Test]
+                    [Repeat(10)]
+                    public void ShouldExcludeParameter()
+                    {
+                        // arrange
+                        var randomNumber = GetRandomInt(100, 103, () => new long[]{101, 102});
+                        // act
+                        // assert
+                        Expect(randomNumber).To.Not.Equal(101);
+                        Expect(randomNumber).To.Not.Equal(102);
+                    }
+                }
+
+                [TestFixture]
+                public class WithMultipleExcludeParameters
+                {
+                    [Test]
+                    [Repeat(10)]
+                    public void ShouldExcludeParameter()
+                    {
+                        // arrange
+                        var randomNumber = GetRandomInt(100, 103, 101, 102);
+                        // act
+                        // assert
+                        Expect(randomNumber).To.Not.Equal(101);
+                        Expect(randomNumber).To.Not.Equal(102);
+                    }
+                }
+            }
         }
 
         [TestFixture]
@@ -394,6 +464,76 @@ namespace PeanutButter.RandomGenerators.Tests
                 Assert.IsTrue(ints.All(i => i >= min));
                 Assert.IsTrue(ints.All(i => i <= max));
                 Assert.IsTrue(ints.Distinct().Count() > 1);
+            }
+            
+            [TestFixture]
+            public class WithExcludeParameter
+            {
+                [TestFixture]
+                public class WhenExcludeParameterIsEqualToMinValueOrMaxValue
+                {
+                    [Test]
+                    public void ShouldThrow()
+                    {
+                        // Arrange
+                        // Act
+                        // Assert
+                        Expect(() => GetRandomLong(1, 100, 100))
+                            .To.Throw<ArgumentException>()
+                            .With.Message.Containing("The exclude parameter can not be equal to minValue or maxValue");
+                        
+                        Expect(() => GetRandomLong(1, 100, 1))
+                            .To.Throw<ArgumentException>()
+                            .With.Message.Containing("The exclude parameter can not be equal to minValue or maxValue");
+                    }
+                }
+
+                [TestFixture]
+                public class WithSingleExcludeFuncParameter
+                {
+                    [Test]
+                    [Repeat(10)]
+                    public void ShouldExcludeParameter()
+                    {
+                        // arrange
+                        var randomNumber = GetRandomLong(100, 102, () => 101);
+                        // act
+                        // assert
+                        Expect(randomNumber).To.Not.Equal(101);
+                    }
+                }
+
+                [TestFixture]
+                public class WithArrayOfExcludeFuncParameters
+                {
+                    [Test]
+                    [Repeat(10)]
+                    public void ShouldExcludeParameter()
+                    {
+                        // arrange
+                        var randomNumber = GetRandomLong(100, 103, () => new long[]{101, 102});
+                        // act
+                        // assert
+                        Expect(randomNumber).To.Not.Equal(101);
+                        Expect(randomNumber).To.Not.Equal(102);
+                    }
+                }
+
+                [TestFixture]
+                public class WithMultipleExcludeParameters
+                {
+                    [Test]
+                    [Repeat(10)]
+                    public void ShouldExcludeParameter()
+                    {
+                        // arrange
+                        var randomNumber = GetRandomLong(100, 103, 101, 102);
+                        // act
+                        // assert
+                        Expect(randomNumber).To.Not.Equal(101);
+                        Expect(randomNumber).To.Not.Equal(102);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
This is a POC for something I think is useful for some use cases I have come across. You will have to let me know what you think about it.

I sometimes find myself writing unit tests where I want to test that a foreign key exception does get thrown for an invalid value. In those cases, it would be useful to say "give me a random number that is not equal to the primary key value of the record I just inserted." That way I get a guaranteed failure every time (which is a valid test). What happens at the moment is every now and then I get tests that fail because the random number I generated is equal to the primary key (by chance) which was inserted, which is not what I want.

This might not be the best way to go about this implementation. Perhaps not having the `params long[]` and only the Func overloads would be less confusing and hence more difficult to make use of the overload by mistake.

Let me know what you think.

