### PR TITLE
:zap: Improved the performance of GetRandomFrom

### DIFF
--- a/source/TestUtils/PeanutButter.RandomGenerators.Tests/TestRandomValueGen.cs
+++ b/source/TestUtils/PeanutButter.RandomGenerators.Tests/TestRandomValueGen.cs
@@ -726,6 +726,55 @@ namespace PeanutButter.RandomGenerators.Tests
                 var o1 = new object();
                 var o2 = new object();
                 var o3 = new object();
+                var items = new List<object> {  };
+                var items2 = new List<object> { o1, o2, o3 };
+                var enumerable = items.Union(items2);
+
+                var results = new List<object>();
+                const int runs = NORMAL_RANDOM_TEST_CYCLES;
+                //---------------Assert Precondition----------------
+
+                //---------------Execute Test ----------------------
+                for (var i = 0; i < runs; i++)
+                {
+                    results.Add(GetRandomFrom(enumerable));
+                }
+
+                //---------------Test Result -----------------------
+                Assert.IsTrue(results.All(r => items2.Contains(r)));
+                Assert.IsTrue(items.All(i => results.Any(r => r == i)));
+            }
+
+            [Test]
+            public void ShouldReturnARandomItemFromTheList()
+            {
+                //---------------Set up test pack-------------------
+                var o1 = new object();
+                var o2 = new object();
+                var o3 = new object();
+                var items = new List<object> { o1, o2, o3 };
+                var results = new List<object>();
+                const int runs = NORMAL_RANDOM_TEST_CYCLES;
+                //---------------Assert Precondition----------------
+
+                //---------------Execute Test ----------------------
+                for (var i = 0; i < runs; i++)
+                {
+                    results.Add(GetRandomFrom(items));
+                }
+
+                //---------------Test Result -----------------------
+                Assert.IsTrue(results.All(r => items.Contains(r)));
+                Assert.IsTrue(items.All(i => results.Any(r => r == i)));
+            }
+
+            [Test]
+            public void ShouldReturnARandomItemFromTheArray()
+            {
+                //---------------Set up test pack-------------------
+                var o1 = new object();
+                var o2 = new object();
+                var o3 = new object();
                 var items = new[] { o1, o2, o3 };
                 var results = new List<object>();
                 const int runs = NORMAL_RANDOM_TEST_CYCLES;

--- a/source/TestUtils/PeanutButter.RandomGenerators/RandomValueGen.cs
+++ b/source/TestUtils/PeanutButter.RandomGenerators/RandomValueGen.cs
@@ -1966,9 +1966,37 @@ namespace PeanutButter.RandomGenerators
         public static T GetRandomFrom<T>(
             IEnumerable<T> items)
         {
-            var itemArray = items as T[] ?? items.ToArray();
+            var itemArray = items.ToArray();
             var upper = itemArray.Length - 1;
             return itemArray.Skip(GetRandomInt(0, upper)).First();
+        }
+
+        /// <summary>
+        /// Gets a random item from the provided list
+        /// </summary>
+        /// <param name="items">List of items</param>
+        /// <typeparam name="T">Item type in list</typeparam>
+        /// <returns>Random value from list; if the list is empty, expect an exception</returns>
+        public static T GetRandomFrom<T>(
+            List<T> items)
+        {
+            int maxValue = items.Count - 1;
+            var index = GetRandomInt(0, maxValue);
+            return items[index];
+        }
+
+        /// <summary>
+        /// Gets a random item from the provided array
+        /// </summary>
+        /// <param name="items">Array of items</param>
+        /// <typeparam name="T">Item type in collection</typeparam>
+        /// <returns>Random value from array; if the array is empty, expect an exception</returns>
+        public static T GetRandomFrom<T>(
+            T[] items)
+        {
+            int maxValue = items.Length - 1;
+            var index = GetRandomInt(0, maxValue);
+            return items[index];
         }
 
         /// <summary>


### PR DESCRIPTION
The problem here seems to be the ToArray, which enumerates the enumerable unnecessarily 

Here is a benchmark of the difference. The benchmark used 1 000 000 items

![image](https://github.com/fluffynuts/PeanutButter/assets/127306160/424a4682-ecf9-4c83-96e6-293c687bd424)

The top 2 entries describe the added code.
The bottom entry show the performance issue when passing a list. The number seems pretty crazy, but it is only 4ms

Don't ask my why it is faster to get an item from a list than from an array 🙃 (Perhaps it has something to do with net70)