### PR TITLE
SimpleHTTPServer: selectable HTTP version in response.

### DIFF
--- a/source/SimpleServers/PeanutButter.SimpleHTTPServer/HttpProcessor.cs
+++ b/source/SimpleServers/PeanutButter.SimpleHTTPServer/HttpProcessor.cs
@@ -456,8 +456,9 @@ public class HttpProcessor : TcpServerProcessor, IProcessor
     /// <param name="message"></param>
     public void WriteStatusHeader(HttpStatusCode code, string message = null)
     {
+        var minorVersion = Server.Version == HttpVersion.Version11 ? 1 : 0;
         LogRequest(code, message);
-        WriteResponseLine($"HTTP/1.0 {(int)code} {message ?? code.ToString()}");
+        WriteResponseLine($"HTTP/1.{minorVersion} {(int)code} {message ?? code.ToString()}");
     }
 
     private void LogRequest(HttpStatusCode code, string message)

--- a/source/SimpleServers/PeanutButter.SimpleHTTPServer/HttpServerBase.cs
+++ b/source/SimpleServers/PeanutButter.SimpleHTTPServer/HttpServerBase.cs
@@ -15,6 +15,22 @@ using PeanutButter.SimpleTcpServer;
 namespace PeanutButter.SimpleHTTPServer
 {
     /// <summary>
+    /// Version of the HTTP protocol.
+    /// </summary>
+    public enum HttpVersion
+    {
+        /// <summary>
+        /// HTTP/1.0
+        /// </summary>
+        Version10 = 0,
+
+        /// <summary>
+        /// HTTP/1.1
+        /// </summary>
+        Version11,
+    } 
+    
+    /// <summary>
     /// Describes the base functionality in a simple http-server
     /// </summary>
     public interface IHttpServerBase: IDisposable
@@ -59,6 +75,12 @@ namespace PeanutButter.SimpleHTTPServer
         /// Flag exposing listening state
         /// </summary>
         bool IsListening { get; }
+        
+        /// <summary>
+        /// HTTP version reported by the server in responses
+        /// Note that this does not change behavior of the server, only the exact format of the response
+        /// </summary>
+        HttpVersion Version { get; set; }
 
         /// <summary>
         /// Handles a request that does not contain a body (as of the HTTP spec).
@@ -102,6 +124,9 @@ namespace PeanutButter.SimpleHTTPServer
         /// Log action used for requests
         /// </summary>
         public Action<RequestLogItem> RequestLogAction { get; set; } = null;
+        
+        /// <inheritdoc />
+        public HttpVersion Version { get; set; }
 
         /// <inheritdoc />
         protected HttpServerBase(int port) : base(port)


### PR DESCRIPTION
This does not change the behavior at all, however is sometimes necessary by some HTTP clients (mostly IoT based). That was exactly my case: my embedded web client (which I can't change) expected to receive HTTP/1.1, otherwise treated is an erroneous response and repeated request.